### PR TITLE
[DOCS] Updating and fixing  LLM-Judge settings issues 

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,10 @@ models:
 | "transcription"  | AsyncOpenAI (Transcriptions)         |
 
 #### Judge Configuration
+LLM-Judge setup is required to run any tasks requiring LLM-judge metrics. For specific task-metric pair compatibility, visit [Task Documentation](./tasks/README.md) and [Metric Documentation](./metrics/README.md).
+Sample LLM-judge configuration is noted below. We provide [sample run_config](./run_configs/mtbench.yaml) that requires LLM-judge setup accordingly.
 ```yaml
-judge_properties:
+judge_settings:
   judge_concurrency: 300 # optional - default is 1
   judge_model: "gpt-4o-mini" # mandatory
   judge_type: "openai" # mandatory (vllm or openai)
@@ -296,7 +298,6 @@ judge_properties:
   judge_api_endpoint: ${API_ENDPOINT} # mandatory
   judge_api_key: ${API_KEY} # mandatory
   judge_temperature: 0.1 # optional
-  judge_prompt_model_override: "Qwen3-32b" # optional
 ```
 
 ### 📝 Task Configuration Options

--- a/run_configs/mtbench.yaml
+++ b/run_configs/mtbench.yaml
@@ -2,6 +2,14 @@ task_metric: # task/group and metric
   - ["mtbench_audio", "mt_bench_llm_judge"]
   - ["mtbench_text", "mt_bench_llm_judge"]
 
+judge_settings:
+  judge_concurrency: 20 # optional - default is 1
+  judge_model: <JUDGE_MODEL_NAME>  # mandatory
+  judge_type: <JUDGE_MODEL_TYPE> # mandatory (vllm or openai)
+  judge_api_version: <JUDGE_MODEL_VERSION> # optional(needed for openai)
+  judge_api_endpoint: <JUDGE_MODEL_ENDPOINT> # mandatory
+  judge_api_key: <JUDGE_MODEL_KEY> # mandatory
+
 models:
   - name: <MODEL_NAME> 
     inference_type: "vllm"


### PR DESCRIPTION
## 📌 Description
Fixing the issue that `llm-judge` settings are not loaded correctly in the current setup. 

## 🔗 Related Issue(s)
N/A

## 🛠️ Type of Change
- Updating documentation to match the `llm-judge` config key as `llm_judge_settings`
- Adding sample `llm_judge_settings` in the sample `run_configs` for future references.

## ✅ How Has This Been Tested?
- [x] Manual testing

### Testing details
- Testing  execution of tasks requiring LLM-as-judge (i.e. `meld_emotion_test`)
- Testing configurations of `llm_judge_settings`, including: `judge_api_key`, `judge_concurrency`, etc. are loaded correctly.

## 📸 Screenshots / Demos
N/A

## 📋 Checklist
- [x] Code follows project style guidelines
- [x] Tests have been added/updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [x] Self-reviewed my code

## 🙌 Additional Notes
<!-- Add any extra context, potential follow-ups, or known issues. -->
